### PR TITLE
fix: leyenda de colores aparece cerrada por defecto

### DIFF
--- a/src/components/ColorLegend.tsx
+++ b/src/components/ColorLegend.tsx
@@ -9,7 +9,7 @@ interface ColorLegendProps {
 }
 
 export const ColorLegend: React.FC<ColorLegendProps> = ({ className = '', theme }) => {
-  const [isExpanded, setIsExpanded] = useState<boolean>(true);
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   // Determinar si estamos en modo oscuro para los estilos condicionales
   const isDarkMode = theme === 'dark';


### PR DESCRIPTION
- Cambiar estado inicial de isExpanded de true a false
- Mejora la experiencia de usuario al no ocupar espacio innecesario al cargar