### PR TITLE
refactor: componentizar odontograma en columnas separadas

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,6 +34,8 @@ import { Odontogram } from 'op-odontogram';
 | `onSimulateBite` | `() => void` | ✅ | Simular animación de mordida |
 | `selectedCaseId` | `string` | ❌ | ID del caso clínico seleccionado |
 | `onCaseSelect` | `(caseId: string) => void` | ❌ | Callback para selección de caso |
+| `developerMode` | `boolean` | ❌ | Activa modo desarrollador con visualización de estructura |
+| `onToggleDeveloperMode` | `(enabled: boolean) => void` | ❌ | Callback para toggle de modo desarrollador |
 
 #### Ejemplo de uso
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Versionado Semántico](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-01-22
+
+### Agregado
+- 🛠️ Modo desarrollador para visualizar estructura del layout con bordes y etiquetas
+- 📏 Sistema de auto-layout con contenedores de altura fija diferenciada
+- 🎯 Altura condicional en AlignedToothContainer según tipo de diente
+- 🔧 Constante TEMPORARY_TOOTH_SLOT_HEIGHT para manejar altura de dientes temporales
+
+### Cambiado
+- 📐 Alturas optimizadas: 130px para dientes permanentes, 100px para temporales
+- 🔧 Refactorización completa del sistema de layout usando offsets positivos
+- 📊 Espaciado mejorado entre dientes y grupos (gap-2)
+- 🎨 Márgenes agregados a etiquetas de grupos para mejor legibilidad (mb-2 superiores, mt-2 inferiores)
+- 📦 Ancho de dientes ahora es dinámico para mejor distribución del espacio
+- 🎯 Eliminación de anchos fijos en favor de min-width para flexibilidad
+
+### Corregido
+- 🦷 Restaurada animación de mordida (boca abierta/cerrada) con showBiteEffect
+- 🐛 Eliminados márgenes internos redundantes (mb-1) que causaban espaciado excesivo
+- 🎯 Alineación vertical mejorada usando offsets consistentes
+- 🔄 Corregida lógica de showBiteEffect en filas temporales para mostrar espacio cuando está activo
+
 ## [1.1.1] - 2024-01-21
 
 ### Documentación

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-odontogram",
   "private": false,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "Una librería de React para crear odontogramas dentales interactivos",
   "keywords": [

--- a/src/lib/odontograma/components/Odontogram.tsx
+++ b/src/lib/odontograma/components/Odontogram.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Tooth } from '../types';
-import { DetailedToothComponent } from './DetailedToothComponent';
-import { AlignedToothContainer } from './AlignedToothContainer';
-import { TOOTH_SLOT_HEIGHT, TEMPORARY_TOOTH_SLOT_HEIGHT, TOOTH_SPACING, DEV_COLORS } from '../constants/layout';
+import { OdontogramColumn1, OdontogramColumn2, OdontogramColumn3 } from './columns';
 
 export interface OdontogramProps {
   teeth: Tooth[];
@@ -144,493 +142,49 @@ export const Odontogram: React.FC<OdontogramProps> = ({
           {/* Estructura de 3 columnas */}
           <div className="flex items-start gap-2 scale-75 sm:scale-90 lg:scale-100">
             {/* Columna 1 - Grupos 1 y 4 */}
-            <div className="flex flex-col">
-              {/* Header Grupo 1 */}
-              <div className="h-[50px] flex flex-col items-center justify-end ">
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
-                  Grupo 1
-                </div>
-                <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
-              </div>
-              
-              {/* Fila 1: Dientes permanentes superiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-end px-2 pb-4 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 1 Row</span>
-                )}
-                <div className={`flex gap-2`}>
-                  {[...grupo1].reverse().map((tooth) => (
-                    <AlignedToothContainer
-                      key={tooth.id}
-                      isUpper={true}
-                      isTemporary={false}
-                      developerMode={developerMode}
-                      toothId={tooth.clinicalId || tooth.id.toString()}
-                    >
-                      <DetailedToothComponent
-                        tooth={tooth}
-                        isSelected={selectedTooth?.id === tooth.id}
-                        onToothClick={onToothClick}
-                        isUpper={true}
-                        developerMode={developerMode}
-                      />
-                    </AlignedToothContainer>
-                  ))}
-                </div>
-              </div>
-              
-              {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-end px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className={`flex gap-2`}>
-                    {[...grupo1Temp].reverse().map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={true}
-                        isTemporary={true}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={true}
-                          developerMode={developerMode}
-                          isTemporary={true}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-end px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className={`flex gap-2`}>
-                    {[...grupo4Temp].reverse().map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={false}
-                        isTemporary={true}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={false}
-                          developerMode={developerMode}
-                          isTemporary={true}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 4: Dientes permanentes inferiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 4 Row</span>
-                )}
-                <div className={`flex gap-2`}>
-                  {[...grupo4].reverse().map((tooth) => (
-                    <AlignedToothContainer
-                      key={tooth.id}
-                      isUpper={false}
-                      isTemporary={false}
-                      developerMode={developerMode}
-                      toothId={tooth.clinicalId || tooth.id.toString()}
-                    >
-                      <DetailedToothComponent
-                        tooth={tooth}
-                        isSelected={selectedTooth?.id === tooth.id}
-                        onToothClick={onToothClick}
-                        isUpper={false}
-                        developerMode={developerMode}
-                      />
-                    </AlignedToothContainer>
-                  ))}
-                </div>
-              </div>
-              
-              {/* Footer Grupo 4 */}
-              <div className="h-[50px] flex flex-col items-center justify-start">
-                <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
-                  Grupo 4
-                </div>
-              </div>
-            </div>
+            <OdontogramColumn1
+              permanentUpperGroup={grupo1}
+              permanentLowerGroup={grupo4}
+              temporaryUpperGroup={grupo1Temp}
+              temporaryLowerGroup={grupo4Temp}
+              showTemporaryTeeth={showTemporaryTeeth}
+              showBiteEffect={showBiteEffect}
+              developerMode={developerMode}
+              selectedTooth={selectedTooth}
+              onToothClick={onToothClick}
+              groupNumber={1}
+              groupLabel="Grupo 1"
+            />
 
             {/* Columna 2 - Grupos 2 y 5 */}
-            <div className="flex flex-col">
-              {/* Header Grupo 2 */}
-              <div className="h-[50px] flex flex-col items-center justify-end ">
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
-                  Grupo 2
-                </div>
-                <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
-              </div>
-              
-              {/* Fila 1: Dientes permanentes superiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-center px-2  ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 2 Row</span>
-                )}
-                <div className="flex items-center gap-1">
-                  {/* Lado derecho del grupo 2 (13, 12, 11) */}
-                  <div className={`flex gap-2`}>
-                    {grupo2Superior.slice(0, 3).reverse().map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={true}
-                        isTemporary={false}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={true}
-                          developerMode={developerMode}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                  {/* Separador entre incisivos centrales */}
-                  <div className="w-0.5 h-16 bg-accent/30 mx-2"></div>
-                  {/* Lado izquierdo del grupo 2 (21, 22, 23) */}
-                  <div className={`flex gap-2`}>
-                    {grupo2Superior.slice(3).map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={true}
-                        isTemporary={false}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={true}
-                          developerMode={developerMode}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                </div>
-              </div>
-              
-              {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-center px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row (Group 2)</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className="flex items-center gap-1">
-                    {/* Lado derecho del grupo 2 temporal */}
-                    <div className={`flex gap-2`}>
-                      {grupo2Temp.slice(0, 3).reverse().map((tooth) => (
-                        <AlignedToothContainer
-                          key={tooth.id}
-                          isUpper={true}
-                          isTemporary={true}
-                          developerMode={developerMode}
-                          toothId={tooth.clinicalId || tooth.id.toString()}
-                        >
-                          <DetailedToothComponent
-                            tooth={tooth}
-                            isSelected={selectedTooth?.id === tooth.id}
-                            onToothClick={onToothClick}
-                            isUpper={true}
-                            isTemporary={true}
-                            developerMode={developerMode}
-                          />
-                        </AlignedToothContainer>
-                      ))}
-                    </div>
-                    {/* Separador entre incisivos centrales */}
-                    <div className="w-0.5 h-12 bg-orange-500/30 mx-2"></div>
-                    {/* Lado izquierdo del grupo 2 temporal */}
-                    <div className={`flex gap-2`}>
-                      {grupo2Temp.slice(3).map((tooth) => (
-                        <AlignedToothContainer
-                          key={tooth.id}
-                          isUpper={true}
-                          isTemporary={true}
-                          developerMode={developerMode}
-                          toothId={tooth.clinicalId || tooth.id.toString()}
-                        >
-                          <DetailedToothComponent
-                            tooth={tooth}
-                            isSelected={selectedTooth?.id === tooth.id}
-                            onToothClick={onToothClick}
-                            isUpper={true}
-                            isTemporary={true}
-                            developerMode={developerMode}
-                          />
-                        </AlignedToothContainer>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-center px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row (Group 5)</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className="flex items-center gap-1">
-                    {/* Lado derecho del grupo 5 temporal */}
-                    <div className={`flex gap-2`}>
-                      {grupo5Temp.slice(0, 3).reverse().map((tooth) => (
-                        <AlignedToothContainer
-                          key={tooth.id}
-                          isUpper={false}
-                          isTemporary={true}
-                          developerMode={developerMode}
-                          toothId={tooth.clinicalId || tooth.id.toString()}
-                        >
-                          <DetailedToothComponent
-                            tooth={tooth}
-                            isSelected={selectedTooth?.id === tooth.id}
-                            onToothClick={onToothClick}
-                            isUpper={false}
-                            isTemporary={true}
-                            developerMode={developerMode}
-                          />
-                        </AlignedToothContainer>
-                      ))}
-                    </div>
-                    {/* Separador entre incisivos centrales */}
-                    <div className="w-0.5 h-12 bg-orange-500/30 mx-2"></div>
-                    {/* Lado izquierdo del grupo 5 temporal */}
-                    <div className={`flex gap-2`}>
-                      {grupo5Temp.slice(3).map((tooth) => (
-                        <AlignedToothContainer
-                          key={tooth.id}
-                          isUpper={false}
-                          isTemporary={true}
-                          developerMode={developerMode}
-                          toothId={tooth.clinicalId || tooth.id.toString()}
-                        >
-                          <DetailedToothComponent
-                            tooth={tooth}
-                            isSelected={selectedTooth?.id === tooth.id}
-                            onToothClick={onToothClick}
-                            isUpper={false}
-                            isTemporary={true}
-                            developerMode={developerMode}
-                          />
-                        </AlignedToothContainer>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 4: Dientes permanentes inferiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-center px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 5 Row</span>
-                )}
-                <div className="flex items-center gap-1">
-                  {/* Lado derecho del grupo 5 (43, 42, 41) */}
-                  <div className={`flex gap-2`}>
-                    {grupo5Inferior.slice(0, 3).reverse().map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={false}
-                        isTemporary={false}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={false}
-                          developerMode={developerMode}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                  {/* Separador entre incisivos centrales */}
-                  <div className="w-0.5 h-16 bg-accent/30 mx-2"></div>
-                  {/* Lado izquierdo del grupo 5 (31, 32, 33) */}
-                  <div className={`flex gap-2`}>
-                    {grupo5Inferior.slice(3).map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={false}
-                        isTemporary={false}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={false}
-                          developerMode={developerMode}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                </div>
-              </div>
-              
-              {/* Footer Grupo 5 */}
-              <div className="h-[50px] flex flex-col items-center justify-start">
-                <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
-                  Grupo 5
-                </div>
-              </div>
-            </div>
+            <OdontogramColumn2
+              permanentUpperGroup={grupo2Superior}
+              permanentLowerGroup={grupo5Inferior}
+              temporaryUpperGroup={grupo2Temp}
+              temporaryLowerGroup={grupo5Temp}
+              showTemporaryTeeth={showTemporaryTeeth}
+              showBiteEffect={showBiteEffect}
+              developerMode={developerMode}
+              selectedTooth={selectedTooth}
+              onToothClick={onToothClick}
+              groupNumber={2}
+              groupLabel="Grupo 2"
+            />
 
             {/* Columna 3 - Grupos 3 y 6 */}
-            <div className="flex flex-col">
-              {/* Header Grupo 3 */}
-              <div className="h-[50px] flex flex-col items-center justify-end   ">
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
-                  Grupo 3
-                </div>
-                <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
-              </div>
-              
-              {/* Fila 1: Dientes permanentes superiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 pb-4 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 3 Row</span>
-                )}
-                <div className={`flex gap-2`}>
-                  {grupo3.map((tooth) => (
-                    <AlignedToothContainer
-                      key={tooth.id}
-                      isUpper={true}
-                      isTemporary={false}
-                      developerMode={developerMode}
-                      toothId={tooth.clinicalId || tooth.id.toString()}
-                    >
-                      <DetailedToothComponent
-                        tooth={tooth}
-                        isSelected={selectedTooth?.id === tooth.id}
-                        onToothClick={onToothClick}
-                        isUpper={true}
-                        developerMode={developerMode}
-                      />
-                    </AlignedToothContainer>
-                  ))}
-                </div>
-              </div>
-              
-              {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-start px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row (Group 3)</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className={`flex gap-2`}>
-                    {grupo3Temp.map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={true}
-                        isTemporary={true}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={true}
-                          developerMode={developerMode}
-                          isTemporary={true}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
-              <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-start px-2 ${showTemporaryTeeth ? 'pb-3' : ''} ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row (Group 6)</span>
-                )}
-                {showTemporaryTeeth && !showBiteEffect && (
-                  <div className={`flex gap-2`}>
-                    {grupo6Temp.map((tooth) => (
-                      <AlignedToothContainer
-                        key={tooth.id}
-                        isUpper={false}
-                        isTemporary={true}
-                        developerMode={developerMode}
-                        toothId={tooth.clinicalId || tooth.id.toString()}
-                      >
-                        <DetailedToothComponent
-                          tooth={tooth}
-                          isSelected={selectedTooth?.id === tooth.id}
-                          onToothClick={onToothClick}
-                          isUpper={false}
-                          developerMode={developerMode}
-                          isTemporary={true}
-                        />
-                      </AlignedToothContainer>
-                    ))}
-                  </div>
-                )}
-              </div>
-              
-              {/* Fila 4: Dientes permanentes inferiores */}
-              <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
-                {developerMode && (
-                  <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 6 Row</span>
-                )}
-                <div className={`flex gap-2`}>
-                  {grupo6.map((tooth) => (
-                    <AlignedToothContainer
-                      key={tooth.id}
-                      isUpper={false}
-                      isTemporary={false}
-                      developerMode={developerMode}
-                      toothId={tooth.clinicalId || tooth.id.toString()}
-                    >
-                      <DetailedToothComponent
-                        tooth={tooth}
-                        isSelected={selectedTooth?.id === tooth.id}
-                        onToothClick={onToothClick}
-                        isUpper={false}
-                        developerMode={developerMode}
-                      />
-                    </AlignedToothContainer>
-                  ))}
-                </div>
-              </div>
-              
-              {/* Footer Grupo 6 */}
-              <div className="h-[50px] flex flex-col items-center justify-start">
-                <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
-                <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
-                  Grupo 6
-                </div>
-              </div>
-            </div>
+            <OdontogramColumn3
+              permanentUpperGroup={grupo3}
+              permanentLowerGroup={grupo6}
+              temporaryUpperGroup={grupo3Temp}
+              temporaryLowerGroup={grupo6Temp}
+              showTemporaryTeeth={showTemporaryTeeth}
+              showBiteEffect={showBiteEffect}
+              developerMode={developerMode}
+              selectedTooth={selectedTooth}
+              onToothClick={onToothClick}
+              groupNumber={3}
+              groupLabel="Grupo 3"
+            />
           </div>
 
           {/* Separador horizontal entre arcadas (posición absoluta) */}

--- a/src/lib/odontograma/components/columns/OdontogramColumn1.tsx
+++ b/src/lib/odontograma/components/columns/OdontogramColumn1.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { DetailedToothComponent } from '../DetailedToothComponent';
+import { AlignedToothContainer } from '../AlignedToothContainer';
+import { TOOTH_SLOT_HEIGHT, TEMPORARY_TOOTH_SLOT_HEIGHT } from '../../constants/layout';
+import { OdontogramColumnProps } from './types';
+
+/**
+ * Columna 1 del odontograma - Grupos 1 y 4
+ * Contiene los molares y premolares del lado derecho
+ */
+export const OdontogramColumn1: React.FC<OdontogramColumnProps> = ({
+  permanentUpperGroup,
+  permanentLowerGroup,
+  temporaryUpperGroup,
+  temporaryLowerGroup,
+  showTemporaryTeeth,
+  showBiteEffect,
+  developerMode,
+  selectedTooth,
+  onToothClick,
+  groupNumber,
+}) => {
+  return (
+    <div className="flex flex-col">
+      {/* Header Grupo 1 */}
+      <div className="h-[50px] flex flex-col items-center justify-end ">
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
+          Grupo 1
+        </div>
+        <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
+      </div>
+      
+      {/* Fila 1: Dientes permanentes superiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-end px-2 pb-4 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 1 Row</span>
+        )}
+        <div className={`flex gap-2`}>
+          {[...permanentUpperGroup].reverse().map((tooth) => (
+            <AlignedToothContainer
+              key={tooth.id}
+              isUpper={true}
+              isTemporary={false}
+              developerMode={developerMode}
+              toothId={tooth.clinicalId || tooth.id.toString()}
+            >
+              <DetailedToothComponent
+                tooth={tooth}
+                isSelected={selectedTooth?.id === tooth.id}
+                onToothClick={onToothClick}
+                isUpper={true}
+                developerMode={developerMode}
+              />
+            </AlignedToothContainer>
+          ))}
+        </div>
+      </div>
+      
+      {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-end px-2  ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className={`flex gap-2`}>
+            {[...temporaryUpperGroup].reverse().map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={true}
+                isTemporary={true}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={true}
+                  developerMode={developerMode}
+                  isTemporary={true}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-end px-2 ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className={`flex gap-2`}>
+            {[...temporaryLowerGroup].reverse().map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={false}
+                isTemporary={true}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={false}
+                  developerMode={developerMode}
+                  isTemporary={true}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 4: Dientes permanentes inferiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 4 Row</span>
+        )}
+        <div className={`flex gap-2`}>
+          {[...permanentLowerGroup].reverse().map((tooth) => (
+            <AlignedToothContainer
+              key={tooth.id}
+              isUpper={false}
+              isTemporary={false}
+              developerMode={developerMode}
+              toothId={tooth.clinicalId || tooth.id.toString()}
+            >
+              <DetailedToothComponent
+                tooth={tooth}
+                isSelected={selectedTooth?.id === tooth.id}
+                onToothClick={onToothClick}
+                isUpper={false}
+                developerMode={developerMode}
+              />
+            </AlignedToothContainer>
+          ))}
+        </div>
+      </div>
+      
+      {/* Footer Grupo 4 */}
+      <div className="h-[50px] flex flex-col items-center justify-start">
+        <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
+          Grupo 4
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/odontograma/components/columns/OdontogramColumn2.tsx
+++ b/src/lib/odontograma/components/columns/OdontogramColumn2.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { DetailedToothComponent } from '../DetailedToothComponent';
+import { AlignedToothContainer } from '../AlignedToothContainer';
+import { TOOTH_SLOT_HEIGHT, TEMPORARY_TOOTH_SLOT_HEIGHT } from '../../constants/layout';
+import { OdontogramColumnProps } from './types';
+
+/**
+ * Columna 2 del odontograma - Grupos 2 y 5
+ * Contiene los incisivos y caninos centrales con separadores
+ */
+export const OdontogramColumn2: React.FC<OdontogramColumnProps> = ({
+  permanentUpperGroup,
+  permanentLowerGroup,
+  temporaryUpperGroup,
+  temporaryLowerGroup,
+  showTemporaryTeeth,
+  showBiteEffect,
+  developerMode,
+  selectedTooth,
+  onToothClick,
+}) => {
+  return (
+    <div className="flex flex-col">
+      {/* Header Grupo 2 */}
+      <div className="h-[50px] flex flex-col items-center justify-end ">
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
+          Grupo 2
+        </div>
+        <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
+      </div>
+      
+      {/* Fila 1: Dientes permanentes superiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-center px-2  ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 2 Row</span>
+        )}
+        <div className="flex items-center gap-1">
+          {/* Lado derecho del grupo 2 (13, 12, 11) */}
+          <div className={`flex gap-2`}>
+            {permanentUpperGroup.slice(0, 3).reverse().map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={true}
+                isTemporary={false}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={true}
+                  developerMode={developerMode}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+          {/* Separador entre incisivos centrales */}
+          <div className="w-0.5 h-16 bg-accent/30 mx-2"></div>
+          {/* Lado izquierdo del grupo 2 (21, 22, 23) */}
+          <div className={`flex gap-2`}>
+            {permanentUpperGroup.slice(3).map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={true}
+                isTemporary={false}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={true}
+                  developerMode={developerMode}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        </div>
+      </div>
+      
+      {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-center px-2  ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row (Group 2)</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className="flex items-center gap-1">
+            {/* Lado derecho del grupo 2 temporal */}
+            <div className={`flex gap-2`}>
+              {temporaryUpperGroup.slice(0, 3).reverse().map((tooth) => (
+                <AlignedToothContainer
+                  key={tooth.id}
+                  isUpper={true}
+                  isTemporary={true}
+                  developerMode={developerMode}
+                  toothId={tooth.clinicalId || tooth.id.toString()}
+                >
+                  <DetailedToothComponent
+                    tooth={tooth}
+                    isSelected={selectedTooth?.id === tooth.id}
+                    onToothClick={onToothClick}
+                    isUpper={true}
+                    isTemporary={true}
+                    developerMode={developerMode}
+                  />
+                </AlignedToothContainer>
+              ))}
+            </div>
+            {/* Separador entre incisivos centrales */}
+            <div className="w-0.5 h-12 bg-orange-500/30 mx-2"></div>
+            {/* Lado izquierdo del grupo 2 temporal */}
+            <div className={`flex gap-2`}>
+              {temporaryUpperGroup.slice(3).map((tooth) => (
+                <AlignedToothContainer
+                  key={tooth.id}
+                  isUpper={true}
+                  isTemporary={true}
+                  developerMode={developerMode}
+                  toothId={tooth.clinicalId || tooth.id.toString()}
+                >
+                  <DetailedToothComponent
+                    tooth={tooth}
+                    isSelected={selectedTooth?.id === tooth.id}
+                    onToothClick={onToothClick}
+                    isUpper={true}
+                    isTemporary={true}
+                    developerMode={developerMode}
+                  />
+                </AlignedToothContainer>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-center px-2  ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row (Group 5)</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className="flex items-center gap-1">
+            {/* Lado derecho del grupo 5 temporal */}
+            <div className={`flex gap-2`}>
+              {temporaryLowerGroup.slice(0, 3).reverse().map((tooth) => (
+                <AlignedToothContainer
+                  key={tooth.id}
+                  isUpper={false}
+                  isTemporary={true}
+                  developerMode={developerMode}
+                  toothId={tooth.clinicalId || tooth.id.toString()}
+                >
+                  <DetailedToothComponent
+                    tooth={tooth}
+                    isSelected={selectedTooth?.id === tooth.id}
+                    onToothClick={onToothClick}
+                    isUpper={false}
+                    isTemporary={true}
+                    developerMode={developerMode}
+                  />
+                </AlignedToothContainer>
+              ))}
+            </div>
+            {/* Separador entre incisivos centrales */}
+            <div className="w-0.5 h-12 bg-orange-500/30 mx-2"></div>
+            {/* Lado izquierdo del grupo 5 temporal */}
+            <div className={`flex gap-2`}>
+              {temporaryLowerGroup.slice(3).map((tooth) => (
+                <AlignedToothContainer
+                  key={tooth.id}
+                  isUpper={false}
+                  isTemporary={true}
+                  developerMode={developerMode}
+                  toothId={tooth.clinicalId || tooth.id.toString()}
+                >
+                  <DetailedToothComponent
+                    tooth={tooth}
+                    isSelected={selectedTooth?.id === tooth.id}
+                    onToothClick={onToothClick}
+                    isUpper={false}
+                    isTemporary={true}
+                    developerMode={developerMode}
+                  />
+                </AlignedToothContainer>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 4: Dientes permanentes inferiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-center px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 5 Row</span>
+        )}
+        <div className="flex items-center gap-1">
+          {/* Lado derecho del grupo 5 (43, 42, 41) */}
+          <div className={`flex gap-2`}>
+            {permanentLowerGroup.slice(0, 3).reverse().map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={false}
+                isTemporary={false}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={false}
+                  developerMode={developerMode}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+          {/* Separador entre incisivos centrales */}
+          <div className="w-0.5 h-16 bg-accent/30 mx-2"></div>
+          {/* Lado izquierdo del grupo 5 (31, 32, 33) */}
+          <div className={`flex gap-2`}>
+            {permanentLowerGroup.slice(3).map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={false}
+                isTemporary={false}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={false}
+                  developerMode={developerMode}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        </div>
+      </div>
+      
+      {/* Footer Grupo 5 */}
+      <div className="h-[50px] flex flex-col items-center justify-start">
+        <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
+          Grupo 5
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/odontograma/components/columns/OdontogramColumn3.tsx
+++ b/src/lib/odontograma/components/columns/OdontogramColumn3.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { DetailedToothComponent } from '../DetailedToothComponent';
+import { AlignedToothContainer } from '../AlignedToothContainer';
+import { TOOTH_SLOT_HEIGHT, TEMPORARY_TOOTH_SLOT_HEIGHT } from '../../constants/layout';
+import { OdontogramColumnProps } from './types';
+
+/**
+ * Columna 3 del odontograma - Grupos 3 y 6
+ * Contiene los molares y premolares del lado izquierdo
+ */
+export const OdontogramColumn3: React.FC<OdontogramColumnProps> = ({
+  permanentUpperGroup,
+  permanentLowerGroup,
+  temporaryUpperGroup,
+  temporaryLowerGroup,
+  showTemporaryTeeth,
+  showBiteEffect,
+  developerMode,
+  selectedTooth,
+  onToothClick,
+}) => {
+  return (
+    <div className="flex flex-col">
+      {/* Header Grupo 3 */}
+      <div className="h-[50px] flex flex-col items-center justify-end   ">
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mb-2">
+          Grupo 3
+        </div>
+        <div className="w-full h-3 border-l-2 border-r-2 border-t-2 border-accent/50 rounded-t-lg"></div>
+      </div>
+      
+      {/* Fila 1: Dientes permanentes superiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 pb-4 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 3 Row</span>
+        )}
+        <div className={`flex gap-2`}>
+          {permanentUpperGroup.map((tooth) => (
+            <AlignedToothContainer
+              key={tooth.id}
+              isUpper={true}
+              isTemporary={false}
+              developerMode={developerMode}
+              toothId={tooth.clinicalId || tooth.id.toString()}
+            >
+              <DetailedToothComponent
+                tooth={tooth}
+                isSelected={selectedTooth?.id === tooth.id}
+                onToothClick={onToothClick}
+                isUpper={true}
+                developerMode={developerMode}
+              />
+            </AlignedToothContainer>
+          ))}
+        </div>
+      </div>
+      
+      {/* Fila 2: Dientes temporales superiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-start px-2  ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Upper Row (Group 3)</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className={`flex gap-2`}>
+            {temporaryUpperGroup.map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={true}
+                isTemporary={true}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={true}
+                  developerMode={developerMode}
+                  isTemporary={true}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 3: Dientes temporales inferiores / Espacio mordida */}
+      <div className={`${showBiteEffect || showTemporaryTeeth ? TEMPORARY_TOOTH_SLOT_HEIGHT : 'h-0 overflow-hidden'} transition-all duration-300 flex items-center justify-start px-2  ${developerMode && showTemporaryTeeth ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Temp Lower Row (Group 6)</span>
+        )}
+        {showTemporaryTeeth && !showBiteEffect && (
+          <div className={`flex gap-2`}>
+            {temporaryLowerGroup.map((tooth) => (
+              <AlignedToothContainer
+                key={tooth.id}
+                isUpper={false}
+                isTemporary={true}
+                developerMode={developerMode}
+                toothId={tooth.clinicalId || tooth.id.toString()}
+              >
+                <DetailedToothComponent
+                  tooth={tooth}
+                  isSelected={selectedTooth?.id === tooth.id}
+                  onToothClick={onToothClick}
+                  isUpper={false}
+                  developerMode={developerMode}
+                  isTemporary={true}
+                />
+              </AlignedToothContainer>
+            ))}
+          </div>
+        )}
+      </div>
+      
+      {/* Fila 4: Dientes permanentes inferiores */}
+      <div className={`${TOOTH_SLOT_HEIGHT} flex items-center justify-start px-2 ${developerMode ? `border-2 border-purple-500 border-dashed relative` : ''}`}>
+        {developerMode && (
+          <span className="absolute -top-6 left-0 text-xs text-purple-600 font-mono bg-white px-1">Grupo 6 Row</span>
+        )}
+        <div className={`flex gap-2`}>
+          {permanentLowerGroup.map((tooth) => (
+            <AlignedToothContainer
+              key={tooth.id}
+              isUpper={false}
+              isTemporary={false}
+              developerMode={developerMode}
+              toothId={tooth.clinicalId || tooth.id.toString()}
+            >
+              <DetailedToothComponent
+                tooth={tooth}
+                isSelected={selectedTooth?.id === tooth.id}
+                onToothClick={onToothClick}
+                isUpper={false}
+                developerMode={developerMode}
+              />
+            </AlignedToothContainer>
+          ))}
+        </div>
+      </div>
+      
+      {/* Footer Grupo 6 */}
+      <div className="h-[50px] flex flex-col items-center justify-start">
+        <div className="w-full h-3 border-l-2 border-r-2 border-b-2 border-accent/50 rounded-b-lg"></div>
+        <div className="px-3 py-1 bg-accent/10 text-accent rounded text-sm font-medium border border-accent/30 mt-2">
+          Grupo 6
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/lib/odontograma/components/columns/index.ts
+++ b/src/lib/odontograma/components/columns/index.ts
@@ -1,0 +1,4 @@
+export { OdontogramColumn1 } from './OdontogramColumn1';
+export { OdontogramColumn2 } from './OdontogramColumn2';
+export { OdontogramColumn3 } from './OdontogramColumn3';
+export type { OdontogramColumnProps, ToothRowProps } from './types';

--- a/src/lib/odontograma/components/columns/types.ts
+++ b/src/lib/odontograma/components/columns/types.ts
@@ -1,0 +1,32 @@
+import { Tooth } from '../../types';
+
+export interface OdontogramColumnProps {
+  // Grupos de dientes
+  permanentUpperGroup: Tooth[];
+  permanentLowerGroup: Tooth[];
+  temporaryUpperGroup: Tooth[];
+  temporaryLowerGroup: Tooth[];
+  
+  // Props de visualización
+  showTemporaryTeeth: boolean;
+  showBiteEffect: boolean;
+  developerMode: boolean;
+  
+  // Props de interacción
+  selectedTooth: Tooth | null;
+  onToothClick: (tooth: Tooth) => void;
+  
+  // Información del grupo
+  groupNumber: number;
+  groupLabel: string;
+}
+
+export interface ToothRowProps {
+  teeth: Tooth[];
+  isUpper: boolean;
+  isTemporary: boolean;
+  selectedTooth: Tooth | null;
+  onToothClick: (tooth: Tooth) => void;
+  developerMode: boolean;
+  reverseOrder?: boolean;
+}


### PR DESCRIPTION
- Extraer cada columna del odontograma en componentes independientes
- Crear directorio components/columns/ para mejor organización
- Separar OdontogramColumn1, OdontogramColumn2 y OdontogramColumn3
- Definir interfaces compartidas en types.ts
- Reducir Odontogram.tsx de 650+ líneas a ~200 líneas
- Mantener toda la funcionalidad existente sin cambios

Esta refactorización mejora la mantenibilidad del código al dividir la lógica en componentes más pequeños y especializados.